### PR TITLE
capture xpdl parse errors for later reporting

### DIFF
--- a/src/zope/wfmc/xpdl-2.1.txt
+++ b/src/zope/wfmc/xpdl-2.1.txt
@@ -462,3 +462,11 @@ Having two ExtendedAttribute elements is nonsense.
     ...
     HandlerError: u"The Name 'ParticipantID' is already used, uniqueness violated, value: 'system' see: Publication."
     File ".../src/zope/wfmc/publication-2.1-duplicate-ExtendedAttribute.xpdl", line 240. in ExtendedAttribute
+
+Sometimes we can't always raise an exception when this happens so instead
+we can record the parse error.
+    >>> xpdl.RAISE_ON_DUPLICATE_ERROR = False
+    >>> package = xpdl.read(open(os.path.join(this_directory, fname)))
+    >>> package.parseErrors
+    [u"The Name 'ParticipantID' is already used, uniqueness violated, value: 'system' see: Publication."]
+    

--- a/src/zope/wfmc/xpdl.py
+++ b/src/zope/wfmc/xpdl.py
@@ -54,6 +54,7 @@ class Package(dict):
         self.applications = {}
         self.participants = {}
         self.script = None
+        self.parseErrors = []
 
     def defineApplications(self, **applications):
         for id, application in applications.items():
@@ -414,7 +415,7 @@ class XPDLHandler(xml.sax.handler.ContentHandler):
                     name, value, self.package.id))
             if RAISE_ON_DUPLICATE_ERROR:
                 raise KeyError(msg)
-            log.error(msg)
+            self.package.parseErrors.append(msg)
 
         container[name] = value
         return container, name


### PR DESCRIPTION
if we detect duplicate extended attributes we will capture these so they can be reported later.
