### PR TITLE
reverting transition count

### DIFF
--- a/src/zope/wfmc/process.py
+++ b/src/zope/wfmc/process.py
@@ -592,7 +592,11 @@ class Activity(persistent.Persistent):
         # Join activites should not have to wait next time you visit them
         # after a true revert
         if self.definition.andJoinSetting:
-            new_num = self.process.get_join_revert_data(self.definition) + 1
+            # the new activity must be one less then the number of in
+            # activities since the number of reverts can not be smaller
+            # then the 1 minus the number of in because the activity is
+            # removed from the map.
+            new_num = len(self.definition.incoming) - 1
             self.process.set_join_revert_data(self.definition, new_num)
         zope.event.notify(ActivityReverted(self))
 


### PR DESCRIPTION
Activities are reverted and deleted so if there are multiple transitions into an AND gate, we must set the total number of transitions -1. In the future when the item is not removed we should set it to -1 of the number of currently tracked transitions in.
