### PR TITLE
Join process.activities and process.finishedActivities

### DIFF
--- a/src/zope/wfmc/deadline.txt
+++ b/src/zope/wfmc/deadline.txt
@@ -82,34 +82,34 @@ Now we can create and execute our process::
     START: First activity
 
 We should be on an activity with a deadline
-    >>> deadlineActivity = proc.activities.values()[0]
+    >>> deadlineActivity = proc.activities.getActive()[0]
     >>> len(deadlineActivity.definition.deadlines)
     1
 
 
 Wait for the deadline to pass
     >>> import datetime, time
-    >>> deadline = proc.activities.values()[0].deadlines[0]
+    >>> deadline = proc.activities.getActive()[0].deadlines[0]
     >>> while datetime.datetime.now() < deadline.deadline_time:
     ...     time.sleep(0.1)
     START: Exception activity
 
 We should have followed the exception transition
-    >>> deadlineActivity not in proc.activities.values()
+    >>> deadlineActivity not in proc.activities.getActive()
     True
-    >>> deadlineActivity in proc.finishedActivities.values()
+    >>> deadlineActivity in proc.activities.getFinished()
     True
     >>> len(deadlineActivity.workitems) > 0
     True
     >>> len(deadlineActivity.finishedWorkitems)
     0
-    >>> proc.activities.values()[0].definition.id
+    >>> proc.activities.getActive()[0].definition.id
     'exception'
 
 Finish normally
-    >>> proc.activities.values()[0].finish()
+    >>> proc.activities.getActive()[0].finish()
     START: Third activity
-    >>> proc.activities.values()[0].finish()
+    >>> proc.activities.getActive()[0].finish()
     >>> proc.isFinished
     True
 
@@ -117,19 +117,19 @@ Do it again without the wait
     >>> proc = mainproc_def(context)
     >>> proc.start()
     START: First activity
-    >>> deadlineActivity = proc.activities.values()[0]
+    >>> deadlineActivity = proc.activities.getActive()[0]
     >>> len(deadlineActivity.definition.deadlines)
     1
-    >>> proc.activities.values()[0].finish()
+    >>> proc.activities.getActive()[0].finish()
     START: Second activity
 
-    >>> deadlineActivity not in proc.activities.values()
+    >>> deadlineActivity not in proc.activities.getActive()
     True
-    >>> deadlineActivity in proc.finishedActivities.values()
+    >>> deadlineActivity in proc.activities.getFinished()
     True
 
-    >>> proc.activities.values()[0].finish()
+    >>> proc.activities.getActive()[0].finish()
     START: Third activity
-    >>> proc.activities.values()[0].finish()
+    >>> proc.activities.getActive()[0].finish()
     >>> proc.isFinished
     True

--- a/src/zope/wfmc/interfaces.py
+++ b/src/zope/wfmc/interfaces.py
@@ -16,6 +16,7 @@
 __docformat__ = "reStructuredText"
 
 from zope import interface
+from zope.interface.common import mapping
 
 SYNCHRONOUS = 'SYNCHR'
 ASYNCHRONOUS = 'ASYNCHR'
@@ -247,6 +248,14 @@ class IProcess(interface.Interface):
         """
         )
 
+    activities = interface.Attribute(
+        """Instance of IActivityContainer.
+
+        Provides access to all activities, created for process (both finished
+        and active).
+        """
+        )
+
     def deadlineTimer(deadline):
         """A function that will time the event of the deadline. it should call
         process.deadlinePassedHandler when the timestamp has passed. This
@@ -279,6 +288,23 @@ class IProcessContext(interface.Interface):
         """
 
 
+class IActivityContainer(mapping.IMapping):
+    """Container for process activities
+
+    A mapping of activity id to activity object. Also provides convenience
+    methods to filter activities.
+    """
+
+    def getActive():
+        """Return list of active (not finished) activities
+        """
+
+    def getFinished():
+        """Return list of all finished activities
+        """
+
+
+
 class IActivity(interface.Interface):
     """Activity instance
     """
@@ -291,6 +317,9 @@ class IActivity(interface.Interface):
         """)
 
     definition = interface.Attribute("Activity definition")
+
+    active = interface.Attribute(
+        "True when activity is active, False when finished")
 
     def start(transition):
         """Start an activity originating from the given transition.

--- a/src/zope/wfmc/subflow.txt
+++ b/src/zope/wfmc/subflow.txt
@@ -110,8 +110,8 @@ Make sure process is finished now::
 
     >>> proc.isFinished
     True
-    >>> proc.activities
-    {}
+    >>> proc.activities.getActive()
+    []
 
 All subflows are registered in main flow
 


### PR DESCRIPTION
Make single object manage all activities. This will make it possible to implement better relational storage for processes.
